### PR TITLE
Log i2c and gpio errors

### DIFF
--- a/ESP32_I2C_Scanner.ino
+++ b/ESP32_I2C_Scanner.ino
@@ -1,0 +1,115 @@
+/*
+ * ESP32 I2C Scanner
+ * 
+ * This utility scans the I2C bus to detect connected devices.
+ * Use this to verify your SSD1306 is properly connected and detected.
+ * 
+ * Hardware Connections:
+ * - ESP32 GPIO 21 (SDA) → SSD1306 SDA
+ * - ESP32 GPIO 22 (SCL) → SSD1306 SCL
+ * - ESP32 3.3V → SSD1306 VCC
+ * - ESP32 GND → SSD1306 GND
+ * - Add 4.7kΩ pull-up resistors on SDA and SCL to 3.3V
+ */
+
+#include <Wire.h>
+
+// I2C configuration
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#define I2C_FREQUENCY 100000  // Start with 100kHz
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+  
+  Serial.println("ESP32 I2C Scanner");
+  Serial.println("================");
+  Serial.println();
+  
+  // Initialize I2C
+  Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
+  Wire.setClock(I2C_FREQUENCY);
+  
+  Serial.println("I2C initialized with:");
+  Serial.print("SDA Pin: ");
+  Serial.println(I2C_SDA_PIN);
+  Serial.print("SCL Pin: ");
+  Serial.println(I2C_SCL_PIN);
+  Serial.print("Frequency: ");
+  Serial.print(I2C_FREQUENCY);
+  Serial.println(" Hz");
+  Serial.println();
+  
+  delay(1000); // Give devices time to initialize
+}
+
+void loop() {
+  Serial.println("Scanning I2C bus...");
+  Serial.println();
+  
+  byte deviceCount = 0;
+  byte errorCount = 0;
+  
+  for (byte address = 1; address < 127; address++) {
+    Wire.beginTransmission(address);
+    byte error = Wire.endTransmission();
+    
+    if (error == 0) {
+      Serial.print("I2C device found at address 0x");
+      if (address < 16) Serial.print("0");
+      Serial.print(address, HEX);
+      Serial.print(" (");
+      Serial.print(address);
+      Serial.print(")");
+      
+      // Check if this might be an SSD1306
+      if (address == 0x3C || address == 0x3D) {
+        Serial.print(" - Likely SSD1306 OLED");
+      }
+      
+      Serial.println();
+      deviceCount++;
+    } else if (error == 4) {
+      errorCount++;
+      Serial.print("Unknown error at address 0x");
+      if (address < 16) Serial.print("0");
+      Serial.print(address, HEX);
+      Serial.println();
+    }
+  }
+  
+  Serial.println();
+  Serial.print("Scan complete. Found ");
+  Serial.print(deviceCount);
+  Serial.print(" device(s)");
+  
+  if (errorCount > 0) {
+    Serial.print(", ");
+    Serial.print(errorCount);
+    Serial.print(" error(s)");
+  }
+  
+  Serial.println();
+  Serial.println();
+  
+  if (deviceCount == 0) {
+    Serial.println("No I2C devices found!");
+    Serial.println();
+    Serial.println("Troubleshooting checklist:");
+    Serial.println("1. Check all connections (SDA, SCL, VCC, GND)");
+    Serial.println("2. Verify power supply (3.3V or 5V)");
+    Serial.println("3. Add pull-up resistors (4.7kΩ on SDA and SCL)");
+    Serial.println("4. Check if device is powered on");
+    Serial.println("5. Try different I2C address (0x3D instead of 0x3C)");
+    Serial.println("6. Lower I2C frequency");
+    Serial.println();
+  } else {
+    Serial.println("I2C devices detected successfully!");
+    Serial.println("You can now use the main SSD1306 example code.");
+  }
+  
+  Serial.println("Rescanning in 5 seconds...");
+  Serial.println("================================================");
+  delay(5000);
+}

--- a/ESP32_SSD1306_Diagnostic.ino
+++ b/ESP32_SSD1306_Diagnostic.ino
@@ -1,0 +1,265 @@
+/*
+ * ESP32 SSD1306 Diagnostic Tool
+ * 
+ * This diagnostic tool helps identify specific issues with your SSD1306 setup.
+ * Run this code to get detailed information about your I2C communication.
+ * 
+ * Features:
+ * - I2C bus scanning
+ * - Device detection
+ * - Error analysis
+ * - Hardware verification
+ * - Connection testing
+ */
+
+#include <Wire.h>
+
+// I2C configuration
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#define I2C_FREQUENCY 100000  // Start with 100kHz
+
+// Test addresses for SSD1306
+#define SSD1306_ADDR_1 0x3C
+#define SSD1306_ADDR_2 0x3D
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+  
+  Serial.println("ESP32 SSD1306 Diagnostic Tool");
+  Serial.println("=============================");
+  Serial.println();
+  
+  // Run comprehensive diagnostics
+  runDiagnostics();
+}
+
+void loop() {
+  // Run diagnostics every 10 seconds
+  static unsigned long lastRun = 0;
+  if (millis() - lastRun > 10000) {
+    Serial.println("\nRe-running diagnostics...");
+    Serial.println("=========================");
+    runDiagnostics();
+    lastRun = millis();
+  }
+  
+  delay(100);
+}
+
+void runDiagnostics() {
+  Serial.println("Starting comprehensive diagnostics...");
+  Serial.println();
+  
+  // Step 1: I2C initialization test
+  testI2CInitialization();
+  
+  // Step 2: I2C bus scan
+  scanI2CBus();
+  
+  // Step 3: SSD1306 specific tests
+  testSSD1306Communication();
+  
+  // Step 4: Error analysis
+  analyzeErrors();
+  
+  // Step 5: Recommendations
+  provideRecommendations();
+  
+  Serial.println("\nDiagnostics complete.");
+  Serial.println("===================");
+}
+
+void testI2CInitialization() {
+  Serial.println("1. Testing I2C Initialization...");
+  
+  // Initialize I2C
+  Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
+  Wire.setClock(I2C_FREQUENCY);
+  
+  Serial.print("   SDA Pin: GPIO ");
+  Serial.println(I2C_SDA_PIN);
+  Serial.print("   SCL Pin: GPIO ");
+  Serial.println(I2C_SCL_PIN);
+  Serial.print("   Frequency: ");
+  Serial.print(I2C_FREQUENCY);
+  Serial.println(" Hz");
+  
+  // Test basic I2C functionality
+  Wire.beginTransmission(0x00);  // Test with non-existent address
+  byte error = Wire.endTransmission();
+  
+  if (error == 2) {
+    Serial.println("   ✓ I2C initialization successful");
+  } else {
+    Serial.print("   ✗ I2C initialization failed (error: ");
+    Serial.print(error);
+    Serial.println(")");
+  }
+  
+  Serial.println();
+}
+
+void scanI2CBus() {
+  Serial.println("2. Scanning I2C Bus...");
+  
+  byte deviceCount = 0;
+  byte errorCount = 0;
+  bool ssd1306Found = false;
+  
+  for (byte address = 1; address < 127; address++) {
+    Wire.beginTransmission(address);
+    byte error = Wire.endTransmission();
+    
+    if (error == 0) {
+      Serial.print("   ✓ Device found at 0x");
+      if (address < 16) Serial.print("0");
+      Serial.print(address, HEX);
+      Serial.print(" (");
+      Serial.print(address);
+      Serial.print(")");
+      
+      // Check if this is likely an SSD1306
+      if (address == SSD1306_ADDR_1 || address == SSD1306_ADDR_2) {
+        Serial.print(" - SSD1306 OLED");
+        ssd1306Found = true;
+      }
+      
+      Serial.println();
+      deviceCount++;
+    } else if (error == 4) {
+      errorCount++;
+    }
+  }
+  
+  Serial.println();
+  Serial.print("   Found ");
+  Serial.print(deviceCount);
+  Serial.print(" device(s)");
+  
+  if (errorCount > 0) {
+    Serial.print(", ");
+    Serial.print(errorCount);
+    Serial.print(" error(s)");
+  }
+  
+  Serial.println();
+  
+  if (deviceCount == 0) {
+    Serial.println("   ✗ No I2C devices detected!");
+  } else if (ssd1306Found) {
+    Serial.println("   ✓ SSD1306 detected!");
+  } else {
+    Serial.println("   ⚠ I2C devices found, but no SSD1306 detected");
+  }
+  
+  Serial.println();
+}
+
+void testSSD1306Communication() {
+  Serial.println("3. Testing SSD1306 Communication...");
+  
+  // Test both common SSD1306 addresses
+  bool addr1Working = testAddress(SSD1306_ADDR_1);
+  bool addr2Working = testAddress(SSD1306_ADDR_2);
+  
+  if (addr1Working) {
+    Serial.println("   ✓ SSD1306 found at address 0x3C");
+  } else if (addr2Working) {
+    Serial.println("   ✓ SSD1306 found at address 0x3D");
+  } else {
+    Serial.println("   ✗ SSD1306 not responding at either address");
+    Serial.println("   ✗ Address 0x3C: Not responding");
+    Serial.println("   ✗ Address 0x3D: Not responding");
+  }
+  
+  Serial.println();
+}
+
+bool testAddress(byte address) {
+  Wire.beginTransmission(address);
+  byte error = Wire.endTransmission();
+  
+  if (error == 0) {
+    // Try to read from the device
+    Wire.requestFrom(address, 1);
+    if (Wire.available()) {
+      return true;
+    }
+  }
+  
+  return false;
+}
+
+void analyzeErrors() {
+  Serial.println("4. Error Analysis...");
+  
+  // Check for common error patterns
+  bool hasNackErrors = false;
+  bool hasTimeoutErrors = false;
+  bool hasBusErrors = false;
+  
+  // Test for NACK errors
+  for (byte address = 1; address < 127; address++) {
+    Wire.beginTransmission(address);
+    byte error = Wire.endTransmission();
+    
+    if (error == 2) {
+      hasNackErrors = true;
+    } else if (error == 3) {
+      hasTimeoutErrors = true;
+    } else if (error == 4) {
+      hasBusErrors = true;
+    }
+  }
+  
+  if (hasNackErrors) {
+    Serial.println("   ⚠ NACK errors detected - device not responding");
+  }
+  
+  if (hasTimeoutErrors) {
+    Serial.println("   ⚠ Timeout errors detected - communication too slow");
+  }
+  
+  if (hasBusErrors) {
+    Serial.println("   ⚠ Bus errors detected - hardware connection issues");
+  }
+  
+  if (!hasNackErrors && !hasTimeoutErrors && !hasBusErrors) {
+    Serial.println("   ✓ No communication errors detected");
+  }
+  
+  Serial.println();
+}
+
+void provideRecommendations() {
+  Serial.println("5. Recommendations...");
+  
+  // Check if SSD1306 was found
+  bool ssd1306Found = false;
+  for (byte address = 1; address < 127; address++) {
+    Wire.beginTransmission(address);
+    byte error = Wire.endTransmission();
+    if (error == 0 && (address == SSD1306_ADDR_1 || address == SSD1306_ADDR_2)) {
+      ssd1306Found = true;
+      break;
+    }
+  }
+  
+  if (ssd1306Found) {
+    Serial.println("   ✓ SSD1306 is working correctly!");
+    Serial.println("   ✓ You can now use the main example code");
+    Serial.println("   ✓ Make sure to use the correct I2C address in your code");
+  } else {
+    Serial.println("   ✗ SSD1306 not detected. Check the following:");
+    Serial.println("   • Verify all connections (SDA, SCL, VCC, GND)");
+    Serial.println("   • Add pull-up resistors (4.7kΩ on SDA and SCL)");
+    Serial.println("   • Check power supply (3.3V or 5V)");
+    Serial.println("   • Verify I2C pins (GPIO 21/22 for most ESP32 boards)");
+    Serial.println("   • Try different I2C frequency (100kHz)");
+    Serial.println("   • Check if display is powered on");
+  }
+  
+  Serial.println();
+}

--- a/ESP32_SSD1306_Example.ino
+++ b/ESP32_SSD1306_Example.ino
@@ -1,0 +1,232 @@
+/*
+ * ESP32 SSD1306 I2C Example with Error Handling
+ * 
+ * This example demonstrates proper I2C configuration for SSD1306 OLED display
+ * with comprehensive error handling and troubleshooting features.
+ * 
+ * Hardware Connections:
+ * - ESP32 GPIO 21 (SDA) → SSD1306 SDA
+ * - ESP32 GPIO 22 (SCL) → SSD1306 SCL
+ * - ESP32 3.3V → SSD1306 VCC
+ * - ESP32 GND → SSD1306 GND
+ * - Add 4.7kΩ pull-up resistors on SDA and SCL to 3.3V
+ * 
+ * Libraries Required:
+ * - Adafruit SSD1306
+ * - Adafruit GFX
+ * - Wire (built-in)
+ */
+
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
+// Display configuration
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+#define OLED_RESET -1
+#define SCREEN_ADDRESS 0x3C  // Try 0x3D if 0x3C doesn't work
+
+// I2C configuration
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#define I2C_FREQUENCY 100000  // Start with 100kHz, increase to 400kHz if stable
+
+// Create display object
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+// Error tracking
+int i2cErrorCount = 0;
+unsigned long lastErrorTime = 0;
+bool displayInitialized = false;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("ESP32 SSD1306 I2C Test");
+  Serial.println("======================");
+  
+  // Initialize I2C with error handling
+  if (!initializeI2C()) {
+    Serial.println("I2C initialization failed!");
+    return;
+  }
+  
+  // Scan I2C bus for devices
+  scanI2CDevices();
+  
+  // Initialize display with retry mechanism
+  if (!initializeDisplay()) {
+    Serial.println("Display initialization failed!");
+    return;
+  }
+  
+  displayInitialized = true;
+  Serial.println("Display initialized successfully!");
+  
+  // Display test content
+  displayTestContent();
+}
+
+void loop() {
+  if (displayInitialized) {
+    // Update display content every 2 seconds
+    static unsigned long lastUpdate = 0;
+    if (millis() - lastUpdate > 2000) {
+      updateDisplayContent();
+      lastUpdate = millis();
+    }
+  } else {
+    // Try to reinitialize display every 5 seconds
+    static unsigned long lastRetry = 0;
+    if (millis() - lastRetry > 5000) {
+      Serial.println("Attempting to reinitialize display...");
+      if (initializeDisplay()) {
+        displayInitialized = true;
+        Serial.println("Display reinitialized successfully!");
+      }
+      lastRetry = millis();
+    }
+  }
+  
+  delay(100);
+}
+
+bool initializeI2C() {
+  Serial.println("Initializing I2C...");
+  
+  // Configure I2C pins (for ESP32)
+  Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
+  
+  // Set I2C frequency
+  Wire.setClock(I2C_FREQUENCY);
+  
+  // Test I2C communication
+  Wire.beginTransmission(SCREEN_ADDRESS);
+  byte error = Wire.endTransmission();
+  
+  if (error == 0) {
+    Serial.println("I2C communication test successful");
+    return true;
+  } else {
+    Serial.print("I2C communication test failed with error: ");
+    Serial.println(error);
+    return false;
+  }
+}
+
+void scanI2CDevices() {
+  Serial.println("Scanning I2C devices...");
+  
+  byte deviceCount = 0;
+  for (byte address = 1; address < 127; address++) {
+    Wire.beginTransmission(address);
+    byte error = Wire.endTransmission();
+    
+    if (error == 0) {
+      Serial.print("I2C device found at address 0x");
+      if (address < 16) Serial.print("0");
+      Serial.print(address, HEX);
+      Serial.println();
+      deviceCount++;
+    }
+  }
+  
+  if (deviceCount == 0) {
+    Serial.println("No I2C devices found!");
+    Serial.println("Check connections and pull-up resistors");
+  } else {
+    Serial.print("Found ");
+    Serial.print(deviceCount);
+    Serial.println(" I2C device(s)");
+  }
+}
+
+bool initializeDisplay() {
+  Serial.println("Initializing SSD1306 display...");
+  
+  // Try to initialize display with retry mechanism
+  for (int attempt = 1; attempt <= 3; attempt++) {
+    Serial.print("Attempt ");
+    Serial.print(attempt);
+    Serial.println("...");
+    
+    if (display.begin(SSD1306_SWITCHCAPVCC, SCREEN_ADDRESS)) {
+      Serial.println("SSD1306 initialization successful");
+      
+      // Clear display buffer
+      display.clearDisplay();
+      display.display();
+      
+      // Add small delay for display to stabilize
+      delay(100);
+      
+      return true;
+    } else {
+      Serial.println("SSD1306 initialization failed");
+      if (attempt < 3) {
+        Serial.println("Retrying in 1 second...");
+        delay(1000);
+      }
+    }
+  }
+  
+  return false;
+}
+
+void displayTestContent() {
+  if (!displayInitialized) return;
+  
+  display.clearDisplay();
+  
+  // Draw test pattern
+  display.setTextSize(1);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0, 0);
+  display.println("ESP32 SSD1306 Test");
+  display.println("==================");
+  display.println();
+  display.println("I2C Address: 0x3C");
+  display.println("Status: OK");
+  display.println();
+  display.println("Time: " + String(millis() / 1000) + "s");
+  
+  display.display();
+}
+
+void updateDisplayContent() {
+  if (!displayInitialized) return;
+  
+  display.clearDisplay();
+  
+  display.setTextSize(1);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0, 0);
+  display.println("ESP32 SSD1306 Test");
+  display.println("==================");
+  display.println();
+  display.println("I2C Address: 0x3C");
+  display.println("Status: Running");
+  display.println();
+  display.println("Uptime: " + String(millis() / 1000) + "s");
+  display.println("Errors: " + String(i2cErrorCount));
+  
+  display.display();
+}
+
+// Error handling function
+void handleI2CError() {
+  i2cErrorCount++;
+  lastErrorTime = millis();
+  
+  Serial.print("I2C Error #");
+  Serial.print(i2cErrorCount);
+  Serial.print(" at time: ");
+  Serial.println(lastErrorTime);
+  
+  // If too many errors, try to reinitialize
+  if (i2cErrorCount > 10) {
+    Serial.println("Too many I2C errors, attempting reinitialization...");
+    displayInitialized = false;
+    i2cErrorCount = 0;
+  }
+}

--- a/ESP32_SSD1306_Hardware_Guide.md
+++ b/ESP32_SSD1306_Hardware_Guide.md
@@ -1,0 +1,185 @@
+# ESP32 SSD1306 Hardware Connection Guide
+
+## Required Components
+
+### Essential Components
+- **ESP32 Development Board** (ESP32-WROOM-32, ESP32-DevKitC, etc.)
+- **SSD1306 OLED Display** (128x64 or 128x32)
+- **Jumper Wires** (4x)
+- **Pull-up Resistors** (2x 4.7kΩ)
+- **Breadboard** (optional but recommended)
+
+### Optional Components
+- **Logic Level Converter** (if using 5V display with 3.3V ESP32)
+- **External Power Supply** (if ESP32 can't provide enough current)
+
+## Pin Connections
+
+### Standard ESP32 I2C Pins
+Most ESP32 boards use these pins for I2C:
+- **SDA**: GPIO 21
+- **SCL**: GPIO 22
+
+### Alternative ESP32 I2C Pins
+Some ESP32 boards may use different pins:
+- **SDA**: GPIO 4, 16, 17, or 21
+- **SCL**: GPIO 5, 15, 18, or 22
+
+**Check your specific ESP32 board documentation for the correct I2C pins.**
+
+## Wiring Diagram
+
+```
+ESP32 Board          SSD1306 Display
+-------------        ----------------
+3.3V          →      VCC
+GND           →      GND
+GPIO 21 (SDA) →      SDA
+GPIO 22 (SCL) →      SCL
+
+Pull-up Resistors:
+SDA → 4.7kΩ → 3.3V
+SCL → 4.7kΩ → 3.3V
+```
+
+## Step-by-Step Connection Guide
+
+### Step 1: Power Connections
+1. Connect **ESP32 3.3V** to **SSD1306 VCC**
+2. Connect **ESP32 GND** to **SSD1306 GND**
+3. **Important**: Ensure stable power supply
+
+### Step 2: I2C Data Connections
+1. Connect **ESP32 GPIO 21** to **SSD1306 SDA**
+2. Connect **ESP32 GPIO 22** to **SSD1306 SCL**
+3. **Important**: Use short, high-quality jumper wires
+
+### Step 3: Pull-up Resistors (CRITICAL)
+1. Connect **4.7kΩ resistor** between **SDA and 3.3V**
+2. Connect **4.7kΩ resistor** between **SCL and 3.3V**
+3. **Important**: These resistors are essential for I2C communication
+
+## Hardware Verification Checklist
+
+### Before Powering On
+- [ ] All connections are secure
+- [ ] No loose wires or connections
+- [ ] Pull-up resistors are properly connected
+- [ ] Power supply voltage is correct (3.3V)
+- [ ] No short circuits between power and ground
+
+### After Powering On
+- [ ] ESP32 boots without errors
+- [ ] SSD1306 display shows any signs of life (backlight, pixels)
+- [ ] No overheating of components
+- [ ] Stable power supply voltage
+
+### Connection Testing
+1. **Continuity Test**: Use multimeter to verify all connections
+2. **Voltage Test**: Measure 3.3V at VCC pin of SSD1306
+3. **Resistance Test**: Check pull-up resistors (should read ~4.7kΩ)
+
+## Common Hardware Issues
+
+### Issue 1: Loose Connections
+**Symptoms**: Intermittent communication, random failures
+**Solution**: Secure all connections, use shorter wires
+
+### Issue 2: Missing Pull-up Resistors
+**Symptoms**: I2C NACK errors, communication failures
+**Solution**: Add 4.7kΩ pull-up resistors on SDA and SCL
+
+### Issue 3: Wrong I2C Pins
+**Symptoms**: No device detection, communication failures
+**Solution**: Check ESP32 board documentation for correct I2C pins
+
+### Issue 4: Power Supply Issues
+**Symptoms**: Display not working, ESP32 resets
+**Solution**: Use stable 3.3V power supply, check current requirements
+
+### Issue 5: Voltage Level Mismatch
+**Symptoms**: Communication errors, display not responding
+**Solution**: Ensure both devices use same voltage level (3.3V)
+
+## Power Requirements
+
+### ESP32 Power Consumption
+- **Typical**: 80-240mA
+- **Peak**: Up to 500mA
+- **Power Supply**: 3.3V (via USB or external supply)
+
+### SSD1306 Power Consumption
+- **Typical**: 20-40mA
+- **Peak**: Up to 100mA
+- **Voltage**: 3.3V or 5V (check display specifications)
+
+### Total Power Requirements
+- **Combined**: 100-340mA typical
+- **Peak**: Up to 600mA
+- **Recommendation**: Use 1A power supply for safety margin
+
+## Troubleshooting Hardware Issues
+
+### No I2C Devices Detected
+1. Check all connections with multimeter
+2. Verify pull-up resistors are connected
+3. Test with I2C scanner code
+4. Try different I2C pins
+5. Check power supply stability
+
+### Intermittent Communication
+1. Secure all connections
+2. Use shorter, higher-quality wires
+3. Add bypass capacitors (100nF) near power pins
+4. Check for loose breadboard connections
+
+### Display Not Working
+1. Verify power supply voltage
+2. Check display specifications (3.3V vs 5V)
+3. Test display with known working setup
+4. Check for damaged display
+
+### ESP32 Resets or Crashes
+1. Check power supply current capacity
+2. Add bypass capacitors
+3. Use external power supply
+4. Check for short circuits
+
+## Advanced Hardware Modifications
+
+### External Power Supply
+If ESP32 can't provide enough current:
+1. Use external 3.3V power supply
+2. Connect to both ESP32 and SSD1306
+3. Ensure common ground connection
+
+### Logic Level Conversion
+If using 5V SSD1306 with 3.3V ESP32:
+1. Use logic level converter
+2. Or use 3.3V SSD1306 display
+3. Or use external 5V power supply
+
+### Improved Signal Integrity
+For better I2C communication:
+1. Use twisted pair wires for SDA/SCL
+2. Keep wires as short as possible
+3. Add bypass capacitors (100nF) near power pins
+4. Use proper grounding
+
+## Safety Considerations
+
+### Electrical Safety
+- Never exceed maximum voltage ratings
+- Use appropriate current limiting
+- Check for short circuits before powering on
+
+### Component Protection
+- Handle components with anti-static precautions
+- Avoid static discharge
+- Use proper soldering techniques
+
+### Power Supply Safety
+- Use regulated power supplies
+- Check voltage before connecting
+- Monitor current consumption
+- Use appropriate fuses or current limiting

--- a/ESP32_SSD1306_Troubleshooting.md
+++ b/ESP32_SSD1306_Troubleshooting.md
@@ -1,0 +1,82 @@
+# ESP32 SSD1306 I2C Troubleshooting Guide
+
+## Error Analysis
+
+Your error logs show:
+- `I2C hardware NACK detected` - Device not responding
+- `I2C transaction unexpected nack detected` - Communication failure
+- `SSD1306: Could not write to device [0x3c at 0]: 259 (ESP_ERR_INVALID_STATE)` - Invalid I2C state
+
+## Common Causes and Solutions
+
+### 1. Hardware Connection Issues
+- **Loose connections**: Check all jumper wires
+- **Wrong pins**: Verify SDA/SCL connections
+- **Power supply**: Ensure 3.3V or 5V power (check display requirements)
+- **Pull-up resistors**: I2C requires 4.7kΩ pull-up resistors on SDA and SCL
+
+### 2. I2C Address Issues
+- **Wrong address**: SSD1306 typically uses 0x3C or 0x3D
+- **Address conflicts**: Check for multiple devices on same address
+
+### 3. ESP32 Configuration Issues
+- **Wrong GPIO pins**: Use correct SDA/SCL pins for your ESP32 board
+- **I2C frequency**: Try lower frequency (100kHz instead of 400kHz)
+- **I2C initialization**: Ensure proper I2C initialization sequence
+
+### 4. Power and Timing Issues
+- **Insufficient power**: Display may not start properly
+- **Timing issues**: Add delays between I2C operations
+- **Display initialization**: SSD1306 requires specific initialization sequence
+
+## Hardware Checklist
+
+### Required Components
+- ESP32 development board
+- SSD1306 OLED display (128x64 or 128x32)
+- Jumper wires
+- 4.7kΩ pull-up resistors (2x)
+- Breadboard (optional)
+
+### Wiring Diagram
+```
+ESP32          SSD1306
+------         -------
+3.3V    →      VCC
+GND     →      GND
+GPIO 21  →     SDA
+GPIO 22  →     SCL
+```
+
+**Note**: Some ESP32 boards use different GPIO pins for I2C. Check your board's documentation.
+
+### Pull-up Resistors
+Connect 4.7kΩ resistors between:
+- SDA and 3.3V
+- SCL and 3.3V
+
+## Software Troubleshooting Steps
+
+1. **Check I2C scanner**: Use I2C scanner to detect devices
+2. **Verify address**: Confirm SSD1306 address (0x3C or 0x3D)
+3. **Lower frequency**: Try 100kHz instead of 400kHz
+4. **Add delays**: Insert delays between I2C operations
+5. **Check initialization**: Ensure proper SSD1306 initialization sequence
+
+## Testing Procedure
+
+1. **Hardware verification**:
+   - Check all connections with multimeter
+   - Verify power supply voltage
+   - Test continuity of all connections
+
+2. **Software verification**:
+   - Run I2C scanner first
+   - Test with minimal code
+   - Gradually add functionality
+
+3. **Common fixes**:
+   - Add pull-up resistors
+   - Lower I2C frequency
+   - Add initialization delays
+   - Check power supply stability


### PR DESCRIPTION
Provide ESP32 SSD1306 I2C troubleshooting tools and guides to resolve NACK and communication failures.

This package addresses common issues like missing pull-up resistors, incorrect I2C addresses, and hardware connection problems, which lead to `I2C hardware NACK detected` and `ESP_ERR_INVALID_STATE` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-49b39c19-0ff6-4a61-862b-0d64876f17e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49b39c19-0ff6-4a61-862b-0d64876f17e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

