### PR TITLE
Log i2c and gpio errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SSD1306 I2C Project CMakeLists.txt
+
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(ssd1306_i2c_project)

--- a/SSD1306_I2C_Troubleshooting.md
+++ b/SSD1306_I2C_Troubleshooting.md
@@ -1,0 +1,68 @@
+# SSD1306 I2C Troubleshooting Guide
+
+## Error Analysis
+
+Your error logs show:
+- `I2C hardware NACK detected` - Device not responding
+- `ESP_ERR_INVALID_STATE` - I2C peripheral in invalid state  
+- `Could not write to device [0x3c at 0]` - Communication failure
+
+## Common Causes & Solutions
+
+### 1. Wiring Issues
+**Problem**: Incorrect connections between ESP32 and SSD1306
+**Solution**: Verify connections:
+- VCC → 3.3V (NOT 5V)
+- GND → GND  
+- SDA → GPIO 21 (default) or GPIO 4
+- SCL → GPIO 22 (default) or GPIO 5
+
+### 2. Pull-up Resistors
+**Problem**: Missing or incorrect pull-up resistors
+**Solution**: Add 4.7kΩ pull-up resistors on SDA and SCL lines
+
+### 3. I2C Address Issues
+**Problem**: Wrong I2C address
+**Solution**: SSD1306 typically uses 0x3C or 0x3D. Try both:
+```cpp
+// Common addresses
+#define SSD1306_ADDRESS_1 0x3C
+#define SSD1306_ADDRESS_2 0x3D
+```
+
+### 4. Power Supply Issues
+**Problem**: Insufficient power or voltage issues
+**Solution**: 
+- Use 3.3V supply (not 5V)
+- Ensure stable power supply
+- Check for voltage drops
+
+### 5. I2C Configuration Issues
+**Problem**: Incorrect I2C configuration
+**Solution**: Use proper I2C settings:
+- Clock speed: 100kHz or 400kHz
+- Proper GPIO configuration
+- Correct I2C mode
+
+### 6. Display Initialization
+**Problem**: Display not properly initialized
+**Solution**: Follow proper initialization sequence
+
+## Diagnostic Steps
+
+1. **Check I2C Scanner**: Use I2C scanner to detect devices
+2. **Verify Wiring**: Double-check all connections
+3. **Test with Multimeter**: Check continuity and voltage levels
+4. **Try Different Addresses**: Test both 0x3C and 0x3D
+5. **Lower Clock Speed**: Try 100kHz instead of 400kHz
+6. **Check Power**: Verify 3.3V supply is stable
+
+## Hardware Checklist
+
+- [ ] VCC connected to 3.3V (not 5V)
+- [ ] GND connected to ground
+- [ ] SDA connected to correct GPIO
+- [ ] SCL connected to correct GPIO  
+- [ ] Pull-up resistors (4.7kΩ) on SDA and SCL
+- [ ] Stable power supply
+- [ ] No loose connections

--- a/WEMOS_LOLIN32_SSD1306_Guide.md
+++ b/WEMOS_LOLIN32_SSD1306_Guide.md
@@ -1,0 +1,127 @@
+# WEMOS LOLIN32 + SSD1306 I2C Troubleshooting Guide
+
+## LOLIN32 Board Specific Information
+
+The WEMOS LOLIN32 board is based on the ESP32 and has specific pin configurations for I2C communication.
+
+### Default I2C Pins for LOLIN32:
+- **SDA (Data)**: GPIO 21
+- **SCL (Clock)**: GPIO 22
+- **VCC**: 3.3V (NOT 5V)
+- **GND**: Ground
+
+### LOLIN32 Pinout Reference:
+```
+LOLIN32 Pin Layout:
+┌─────────────────┐
+│ 3V3  GND  GPIO23│
+│ GND  GPIO22 SCL │  ← I2C Clock
+│ GPIO21 SDA │  ← I2C Data  
+│ GND  GPIO19 GND │
+│ GND  GPIO18 GND │
+│ GND  GPIO5  GND │
+│ GND  GPIO17 GND │
+│ GND  GPIO16 GND │
+│ GND  GPIO4  GND │
+│ GND  GPIO0  GND │
+│ GND  GPIO2  GND │
+│ GND  GPIO15 GND │
+│ GND  GPIO13 GND │
+│ GND  GPIO12 GND │
+│ GND  GPIO14 GND │
+│ GND  GPIO27 GND │
+│ GND  GPIO26 GND │
+│ GND  GPIO25 GND │
+│ GND  GPIO33 GND │
+│ GND  GPIO32 GND │
+│ GND  GPIO35 GND │
+│ GND  GPIO34 GND │
+└─────────────────┘
+```
+
+## Common LOLIN32 + SSD1306 Issues
+
+### 1. Power Supply Issues
+**Problem**: LOLIN32 provides 3.3V, but some SSD1306 modules expect 5V
+**Solution**: 
+- Use 3.3V compatible SSD1306 modules
+- If using 5V module, add level shifter
+- Check voltage with multimeter
+
+### 2. Pull-up Resistor Issues
+**Problem**: LOLIN32 doesn't have built-in pull-ups for I2C
+**Solution**: Add external 4.7kΩ pull-up resistors:
+- SDA → 3.3V (via 4.7kΩ resistor)
+- SCL → 3.3V (via 4.7kΩ resistor)
+
+### 3. GPIO Configuration
+**Problem**: Using wrong GPIO pins
+**Solution**: Use correct pins:
+- SDA: GPIO 21
+- SCL: GPIO 22
+- NOT GPIO 4/5 (which you were using)
+
+### 4. I2C Address Issues
+**Problem**: Wrong I2C address
+**Solution**: Try both addresses:
+- 0x3C (most common)
+- 0x3D (alternative)
+
+## Wiring Diagram for LOLIN32 + SSD1306
+
+```
+LOLIN32          SSD1306
+------           -------
+3.3V      →      VCC
+GND       →      GND
+GPIO 21   →      SDA
+GPIO 22   →      SCL
+
+Pull-up resistors:
+SDA → 3.3V (4.7kΩ)
+SCL → 3.3V (4.7kΩ)
+```
+
+## Troubleshooting Steps
+
+1. **Verify Connections**:
+   - Double-check all wiring
+   - Ensure no loose connections
+   - Verify 3.3V power supply
+
+2. **Add Pull-up Resistors**:
+   - Essential for LOLIN32
+   - Use 4.7kΩ resistors
+   - Connect to 3.3V
+
+3. **Test with I2C Scanner**:
+   - Use the provided scanner code
+   - Check for device detection
+   - Verify correct address
+
+4. **Check Power Supply**:
+   - Measure 3.3V with multimeter
+   - Ensure stable power
+   - Check for voltage drops
+
+## LOLIN32 Specific Code Configuration
+
+The code should use:
+```c
+#define I2C_MASTER_SDA_IO           21    // GPIO 21 for SDA
+#define I2C_MASTER_SCL_IO           22    // GPIO 22 for SCL
+```
+
+## Common Error Solutions
+
+### Error: "I2C hardware NACK detected"
+- **Cause**: No pull-up resistors or wrong address
+- **Solution**: Add 4.7kΩ pull-ups, check address
+
+### Error: "ESP_ERR_INVALID_STATE"
+- **Cause**: Wrong GPIO configuration
+- **Solution**: Use GPIO 21/22, not 4/5
+
+### Error: "Could not write to device"
+- **Cause**: Power supply or wiring issues
+- **Solution**: Check 3.3V supply, verify connections

--- a/i2c_scanner.c
+++ b/i2c_scanner.c
@@ -1,0 +1,215 @@
+/*
+ * I2C Scanner for ESP32
+ * This tool helps diagnose I2C communication issues
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/i2c.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_err.h"
+
+static const char *TAG = "I2C_SCANNER";
+
+// I2C Configuration
+#define I2C_MASTER_SCL_IO           22    /*!< GPIO number used for I2C master clock */
+#define I2C_MASTER_SDA_IO           21    /*!< GPIO number used for I2C master data  */
+#define I2C_MASTER_NUM              0     /*!< I2C master i2c port number */
+#define I2C_MASTER_FREQ_HZ          100000 /*!< I2C master clock frequency */
+#define I2C_MASTER_TX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_TIMEOUT_MS       1000
+
+/**
+ * @brief Initialize I2C master
+ */
+static esp_err_t i2c_master_init(void)
+{
+    int i2c_master_port = I2C_MASTER_NUM;
+
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = I2C_MASTER_FREQ_HZ,
+    };
+
+    i2c_param_config(i2c_master_port, &conf);
+
+    return i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+}
+
+/**
+ * @brief Scan for I2C devices
+ */
+static void i2c_scanner(void)
+{
+    ESP_LOGI(TAG, "Starting I2C scanner...");
+    ESP_LOGI(TAG, "Scanning I2C bus on SDA=%d, SCL=%d", I2C_MASTER_SDA_IO, I2C_MASTER_SCL_IO);
+    
+    int devices_found = 0;
+    
+    for (uint8_t addr = 1; addr < 127; addr++) {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_WRITE, true);
+        i2c_master_stop(cmd);
+        
+        esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+        
+        if (ret == ESP_OK) {
+            ESP_LOGI(TAG, "I2C device found at address 0x%02X", addr);
+            devices_found++;
+            
+            // Check if it's a known device
+            if (addr == 0x3C || addr == 0x3D) {
+                ESP_LOGI(TAG, "  -> This could be an SSD1306 OLED display");
+            } else if (addr == 0x48) {
+                ESP_LOGI(TAG, "  -> This could be a temperature sensor (DS18B20)");
+            } else if (addr == 0x50) {
+                ESP_LOGI(TAG, "  -> This could be an EEPROM");
+            } else if (addr == 0x68) {
+                ESP_LOGI(TAG, "  -> This could be an RTC (DS1307)");
+            }
+        }
+        
+        vTaskDelay(pdMS_TO_TICKS(10)); // Small delay between scans
+    }
+    
+    if (devices_found == 0) {
+        ESP_LOGW(TAG, "No I2C devices found!");
+        ESP_LOGW(TAG, "Check your wiring:");
+        ESP_LOGW(TAG, "  - SDA connected to GPIO %d", I2C_MASTER_SDA_IO);
+        ESP_LOGW(TAG, "  - SCL connected to GPIO %d", I2C_MASTER_SCL_IO);
+        ESP_LOGW(TAG, "  - Pull-up resistors (4.7kΩ) on SDA and SCL");
+        ESP_LOGW(TAG, "  - Power supply (3.3V)");
+    } else {
+        ESP_LOGI(TAG, "Scan complete. Found %d device(s)", devices_found);
+    }
+}
+
+/**
+ * @brief Test I2C communication with specific address
+ */
+static void test_i2c_communication(uint8_t address)
+{
+    ESP_LOGI(TAG, "Testing communication with device at 0x%02X", address);
+    
+    // Test 1: Basic write
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, 0x00, true); // Send a simple command
+    i2c_master_stop(cmd);
+    
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "✓ Basic write test passed for 0x%02X", address);
+    } else {
+        ESP_LOGE(TAG, "✗ Basic write test failed for 0x%02X: %s", address, esp_err_to_name(ret));
+    }
+    
+    vTaskDelay(pdMS_TO_TICKS(100));
+    
+    // Test 2: Read test (if device supports it)
+    uint8_t data;
+    cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_READ, true);
+    i2c_master_read_byte(cmd, &data, I2C_MASTER_NACK);
+    i2c_master_stop(cmd);
+    
+    ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "✓ Basic read test passed for 0x%02X (data: 0x%02X)", address, data);
+    } else {
+        ESP_LOGW(TAG, "⚠ Basic read test failed for 0x%02X: %s (this may be normal for some devices)", address, esp_err_to_name(ret));
+    }
+}
+
+/**
+ * @brief Test different I2C clock speeds
+ */
+static void test_i2c_speeds(void)
+{
+    ESP_LOGI(TAG, "Testing different I2C clock speeds...");
+    
+    uint32_t speeds[] = {100000, 400000, 1000000};
+    const char* speed_names[] = {"100kHz", "400kHz", "1MHz"};
+    
+    for (int i = 0; i < 3; i++) {
+        ESP_LOGI(TAG, "Testing at %s", speed_names[i]);
+        
+        // Reconfigure I2C with new speed
+        i2c_driver_delete(I2C_MASTER_NUM);
+        vTaskDelay(pdMS_TO_TICKS(100));
+        
+        i2c_config_t conf = {
+            .mode = I2C_MODE_MASTER,
+            .sda_io_num = I2C_MASTER_SDA_IO,
+            .scl_io_num = I2C_MASTER_SCL_IO,
+            .sda_pullup_en = GPIO_PULLUP_ENABLE,
+            .scl_pullup_en = GPIO_PULLUP_ENABLE,
+            .master.clk_speed = speeds[i],
+        };
+        
+        i2c_param_config(I2C_MASTER_NUM, &conf);
+        esp_err_t ret = i2c_driver_install(I2C_MASTER_NUM, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+        
+        if (ret == ESP_OK) {
+            // Test communication with SSD1306 addresses
+            test_i2c_communication(0x3C);
+            test_i2c_communication(0x3D);
+        } else {
+            ESP_LOGE(TAG, "Failed to configure I2C at %s", speed_names[i]);
+        }
+        
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
+
+/**
+ * @brief Main application
+ */
+void app_main(void)
+{
+    ESP_LOGI(TAG, "I2C Diagnostic Tool Starting");
+    
+    // Initialize I2C
+    esp_err_t ret = i2c_master_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C master init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "I2C master initialized successfully");
+    
+    // Wait a bit for I2C to stabilize
+    vTaskDelay(pdMS_TO_TICKS(1000));
+    
+    // Run I2C scanner
+    i2c_scanner();
+    
+    vTaskDelay(pdMS_TO_TICKS(2000));
+    
+    // Test specific addresses
+    ESP_LOGI(TAG, "Testing specific SSD1306 addresses...");
+    test_i2c_communication(0x3C);
+    test_i2c_communication(0x3D);
+    
+    vTaskDelay(pdMS_TO_TICKS(2000));
+    
+    // Test different clock speeds
+    test_i2c_speeds();
+    
+    ESP_LOGI(TAG, "I2C diagnostic complete");
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "ssd1306_corrected_example.c"
+                    INCLUDE_DIRS ".")

--- a/main/lolin32_ssd1306_example.c
+++ b/main/lolin32_ssd1306_example.c
@@ -1,6 +1,6 @@
 /*
- * SSD1306 I2C Communication - Corrected Example
- * This example addresses common I2C communication issues
+ * WEMOS LOLIN32 + SSD1306 I2C Communication Example
+ * Specifically configured for LOLIN32 board
  */
 
 #include <stdio.h>
@@ -12,19 +12,20 @@
 #include "esp_log.h"
 #include "esp_err.h"
 
-static const char *TAG = "SSD1306";
+static const char *TAG = "LOLIN32_SSD1306";
 
-// I2C Configuration for WEMOS LOLIN32
-#define I2C_MASTER_SCL_IO           22    /*!< GPIO number used for I2C master clock (LOLIN32 default) */
-#define I2C_MASTER_SDA_IO           21    /*!< GPIO number used for I2C master data (LOLIN32 default) */
-#define I2C_MASTER_NUM              0     /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
-#define I2C_MASTER_FREQ_HZ          100000 /*!< I2C master clock frequency */
+// LOLIN32 I2C Configuration
+#define I2C_MASTER_SCL_IO           22    /*!< LOLIN32 SCL pin */
+#define I2C_MASTER_SDA_IO           21    /*!< LOLIN32 SDA pin */
+#define I2C_MASTER_NUM              0     /*!< I2C master port number */
+#define I2C_MASTER_FREQ_HZ          100000 /*!< I2C clock frequency - start with 100kHz */
 #define I2C_MASTER_TX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
 #define I2C_MASTER_RX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
 #define I2C_MASTER_TIMEOUT_MS       1000
 
 // SSD1306 Configuration
-#define SSD1306_I2C_ADDR            0x3C  /*!< I2C address for SSD1306 */
+#define SSD1306_I2C_ADDR_1          0x3C  /*!< Primary SSD1306 I2C address */
+#define SSD1306_I2C_ADDR_2          0x3D  /*!< Alternative SSD1306 I2C address */
 #define SSD1306_WIDTH               128
 #define SSD1306_HEIGHT              64
 
@@ -41,31 +42,89 @@ static const char *TAG = "SSD1306";
 #define SSD1306_CMD_SET_PRECHARGE_PERIOD    0xD9
 #define SSD1306_CMD_SET_COM_PINS            0xDA
 #define SSD1306_CMD_SET_VCOMH_DESELECT      0xDB
-#define SSD1306_CMD_SET_CONTRAST            0x81
-#define SSD1306_CMD_SET_ENTIRE_ON           0xA4
+#define SSD1306_CMD_SET_CONTRAST              0x81
+#define SSD1306_CMD_SET_ENTIRE_ON            0xA4
 #define SSD1306_CMD_SET_NORMAL_INV           0xA6
-#define SSD1306_CMD_SET_DISPLAY_ON          0xAF
-#define SSD1306_CMD_SET_DISPLAY_OFF         0xAE
+#define SSD1306_CMD_SET_DISPLAY_ON           0xAF
+#define SSD1306_CMD_SET_DISPLAY_OFF          0xAE
+
+// Global variable to store the correct I2C address
+static uint8_t ssd1306_address = 0;
 
 /**
- * @brief Initialize I2C master
+ * @brief Initialize I2C master for LOLIN32
  */
 static esp_err_t i2c_master_init(void)
 {
+    ESP_LOGI(TAG, "Initializing I2C master for LOLIN32...");
+    ESP_LOGI(TAG, "SDA: GPIO %d, SCL: GPIO %d", I2C_MASTER_SDA_IO, I2C_MASTER_SCL_IO);
+    
     int i2c_master_port = I2C_MASTER_NUM;
 
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
         .sda_io_num = I2C_MASTER_SDA_IO,
         .scl_io_num = I2C_MASTER_SCL_IO,
-        .sda_pullup_en = GPIO_PULLUP_ENABLE,
-        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,  // Enable internal pull-ups
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,  // Enable internal pull-ups
         .master.clk_speed = I2C_MASTER_FREQ_HZ,
     };
 
     i2c_param_config(i2c_master_port, &conf);
 
-    return i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+    esp_err_t ret = i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+    
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "I2C master initialized successfully");
+    } else {
+        ESP_LOGE(TAG, "I2C master initialization failed: %s", esp_err_to_name(ret));
+    }
+    
+    return ret;
+}
+
+/**
+ * @brief Scan for SSD1306 device
+ */
+static esp_err_t scan_ssd1306(void)
+{
+    ESP_LOGI(TAG, "Scanning for SSD1306 device...");
+    
+    // Try address 0x3C first
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR_1 << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_stop(cmd);
+    
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    
+    if (ret == ESP_OK) {
+        ssd1306_address = SSD1306_I2C_ADDR_1;
+        ESP_LOGI(TAG, "SSD1306 found at address 0x%02X", ssd1306_address);
+        return ESP_OK;
+    }
+    
+    // Try address 0x3D
+    cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR_2 << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_stop(cmd);
+    
+    ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    
+    if (ret == ESP_OK) {
+        ssd1306_address = SSD1306_I2C_ADDR_2;
+        ESP_LOGI(TAG, "SSD1306 found at address 0x%02X", ssd1306_address);
+        return ESP_OK;
+    }
+    
+    ESP_LOGE(TAG, "SSD1306 not found at either address (0x3C or 0x3D)");
+    ESP_LOGE(TAG, "Check wiring: SDA->GPIO%d, SCL->GPIO%d, VCC->3.3V, GND->GND", I2C_MASTER_SDA_IO, I2C_MASTER_SCL_IO);
+    ESP_LOGE(TAG, "Add 4.7kΩ pull-up resistors on SDA and SCL lines");
+    
+    return ESP_FAIL;
 }
 
 /**
@@ -75,7 +134,7 @@ static esp_err_t ssd1306_write_command(uint8_t command)
 {
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
     i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, (ssd1306_address << 1) | I2C_MASTER_WRITE, true);
     i2c_master_write_byte(cmd, 0x00, true); // Control byte: Co=0, D/C#=0
     i2c_master_write_byte(cmd, command, true);
     i2c_master_stop(cmd);
@@ -91,7 +150,7 @@ static esp_err_t ssd1306_write_data(uint8_t *data, size_t len)
 {
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
     i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, (ssd1306_address << 1) | I2C_MASTER_WRITE, true);
     i2c_master_write_byte(cmd, 0x40, true); // Control byte: Co=0, D/C#=1
     i2c_master_write(cmd, data, len, true);
     i2c_master_stop(cmd);
@@ -105,11 +164,16 @@ static esp_err_t ssd1306_write_data(uint8_t *data, size_t len)
  */
 static esp_err_t ssd1306_init(void)
 {
+    ESP_LOGI(TAG, "Initializing SSD1306 display...");
+    
     esp_err_t ret = ESP_OK;
     
     // Display off
     ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_OFF);
-    if (ret != ESP_OK) return ret;
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to turn display off: %s", esp_err_to_name(ret));
+        return ret;
+    }
     
     vTaskDelay(pdMS_TO_TICKS(10));
     
@@ -191,6 +255,7 @@ static esp_err_t ssd1306_init(void)
     ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_ON);
     if (ret != ESP_OK) return ret;
     
+    ESP_LOGI(TAG, "SSD1306 initialization completed successfully");
     return ret;
 }
 
@@ -199,6 +264,8 @@ static esp_err_t ssd1306_init(void)
  */
 static esp_err_t ssd1306_clear(void)
 {
+    ESP_LOGI(TAG, "Clearing display...");
+    
     uint8_t zeros[SSD1306_WIDTH];
     memset(zeros, 0, SSD1306_WIDTH);
     
@@ -221,7 +288,35 @@ static esp_err_t ssd1306_clear(void)
         if (ret != ESP_OK) return ret;
     }
     
+    ESP_LOGI(TAG, "Display cleared successfully");
     return ret;
+}
+
+/**
+ * @brief Test I2C communication with retry mechanism
+ */
+static esp_err_t test_i2c_communication(void)
+{
+    ESP_LOGI(TAG, "Testing I2C communication...");
+    
+    for (int attempt = 1; attempt <= 3; attempt++) {
+        ESP_LOGI(TAG, "Attempt %d/3", attempt);
+        
+        esp_err_t ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_OFF);
+        if (ret == ESP_OK) {
+            ESP_LOGI(TAG, "I2C communication test successful");
+            return ESP_OK;
+        } else {
+            ESP_LOGW(TAG, "I2C communication test failed: %s", esp_err_to_name(ret));
+            if (attempt < 3) {
+                ESP_LOGI(TAG, "Retrying in 1 second...");
+                vTaskDelay(pdMS_TO_TICKS(1000));
+            }
+        }
+    }
+    
+    ESP_LOGE(TAG, "I2C communication test failed after 3 attempts");
+    return ESP_FAIL;
 }
 
 /**
@@ -229,7 +324,10 @@ static esp_err_t ssd1306_clear(void)
  */
 void app_main(void)
 {
-    ESP_LOGI(TAG, "Starting SSD1306 I2C Test");
+    ESP_LOGI(TAG, "Starting WEMOS LOLIN32 + SSD1306 Test");
+    ESP_LOGI(TAG, "Board: WEMOS LOLIN32");
+    ESP_LOGI(TAG, "Display: SSD1306 OLED");
+    ESP_LOGI(TAG, "I2C Pins: SDA=GPIO%d, SCL=GPIO%d", I2C_MASTER_SDA_IO, I2C_MASTER_SCL_IO);
     
     // Initialize I2C
     esp_err_t ret = i2c_master_init();
@@ -237,7 +335,27 @@ void app_main(void)
         ESP_LOGE(TAG, "I2C master init failed: %s", esp_err_to_name(ret));
         return;
     }
-    ESP_LOGI(TAG, "I2C master initialized successfully");
+    
+    // Wait for I2C to stabilize
+    vTaskDelay(pdMS_TO_TICKS(100));
+    
+    // Scan for SSD1306 device
+    ret = scan_ssd1306();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SSD1306 device not found");
+        ESP_LOGE(TAG, "Please check:");
+        ESP_LOGE(TAG, "1. Wiring: SDA->GPIO%d, SCL->GPIO%d, VCC->3.3V, GND->GND", I2C_MASTER_SDA_IO, I2C_MASTER_SCL_IO);
+        ESP_LOGE(TAG, "2. Pull-up resistors: 4.7kΩ on SDA and SCL lines");
+        ESP_LOGE(TAG, "3. Power supply: 3.3V stable");
+        return;
+    }
+    
+    // Test I2C communication
+    ret = test_i2c_communication();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C communication test failed");
+        return;
+    }
     
     // Initialize SSD1306
     ret = ssd1306_init();
@@ -245,7 +363,6 @@ void app_main(void)
         ESP_LOGE(TAG, "SSD1306 init failed: %s", esp_err_to_name(ret));
         return;
     }
-    ESP_LOGI(TAG, "SSD1306 initialized successfully");
     
     // Clear display
     ret = ssd1306_clear();
@@ -253,7 +370,9 @@ void app_main(void)
         ESP_LOGE(TAG, "SSD1306 clear failed: %s", esp_err_to_name(ret));
         return;
     }
-    ESP_LOGI(TAG, "Display cleared successfully");
     
-    ESP_LOGI(TAG, "SSD1306 test completed successfully!");
+    ESP_LOGI(TAG, "=== SUCCESS ===");
+    ESP_LOGI(TAG, "WEMOS LOLIN32 + SSD1306 test completed successfully!");
+    ESP_LOGI(TAG, "Device address: 0x%02X", ssd1306_address);
+    ESP_LOGI(TAG, "Display is ready for use");
 }

--- a/main/ssd1306_corrected_example.c
+++ b/main/ssd1306_corrected_example.c
@@ -1,0 +1,259 @@
+/*
+ * SSD1306 I2C Communication - Corrected Example
+ * This example addresses common I2C communication issues
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/i2c.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_err.h"
+
+static const char *TAG = "SSD1306";
+
+// I2C Configuration
+#define I2C_MASTER_SCL_IO           22    /*!< GPIO number used for I2C master clock */
+#define I2C_MASTER_SDA_IO           21    /*!< GPIO number used for I2C master data  */
+#define I2C_MASTER_NUM              0     /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
+#define I2C_MASTER_FREQ_HZ          100000 /*!< I2C master clock frequency */
+#define I2C_MASTER_TX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_TIMEOUT_MS       1000
+
+// SSD1306 Configuration
+#define SSD1306_I2C_ADDR            0x3C  /*!< I2C address for SSD1306 */
+#define SSD1306_WIDTH               128
+#define SSD1306_HEIGHT              64
+
+// SSD1306 Commands
+#define SSD1306_CMD_SET_MEMORY_ADDR_MODE    0x20
+#define SSD1306_CMD_SET_COLUMN_ADDR         0x21
+#define SSD1306_CMD_SET_PAGE_ADDR           0x22
+#define SSD1306_CMD_SET_DISPLAY_START_LINE  0x40
+#define SSD1306_CMD_SET_SEGMENT_REMAP       0xA0
+#define SSD1306_CMD_SET_MULTIPLEX_RATIO     0xA8
+#define SSD1306_CMD_SET_COM_SCAN_DIR        0xC0
+#define SSD1306_CMD_SET_DISPLAY_OFFSET      0xD3
+#define SSD1306_CMD_SET_CLOCK_DIV           0xD5
+#define SSD1306_CMD_SET_PRECHARGE_PERIOD    0xD9
+#define SSD1306_CMD_SET_COM_PINS            0xDA
+#define SSD1306_CMD_SET_VCOMH_DESELECT      0xDB
+#define SSD1306_CMD_SET_CONTRAST            0x81
+#define SSD1306_CMD_SET_ENTIRE_ON           0xA4
+#define SSD1306_CMD_SET_NORMAL_INV           0xA6
+#define SSD1306_CMD_SET_DISPLAY_ON          0xAF
+#define SSD1306_CMD_SET_DISPLAY_OFF         0xAE
+
+/**
+ * @brief Initialize I2C master
+ */
+static esp_err_t i2c_master_init(void)
+{
+    int i2c_master_port = I2C_MASTER_NUM;
+
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = I2C_MASTER_FREQ_HZ,
+    };
+
+    i2c_param_config(i2c_master_port, &conf);
+
+    return i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+}
+
+/**
+ * @brief Write a command to SSD1306
+ */
+static esp_err_t ssd1306_write_command(uint8_t command)
+{
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, 0x00, true); // Control byte: Co=0, D/C#=0
+    i2c_master_write_byte(cmd, command, true);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    return ret;
+}
+
+/**
+ * @brief Write data to SSD1306
+ */
+static esp_err_t ssd1306_write_data(uint8_t *data, size_t len)
+{
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, 0x40, true); // Control byte: Co=0, D/C#=1
+    i2c_master_write(cmd, data, len, true);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    return ret;
+}
+
+/**
+ * @brief Initialize SSD1306 display
+ */
+static esp_err_t ssd1306_init(void)
+{
+    esp_err_t ret = ESP_OK;
+    
+    // Display off
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_OFF);
+    if (ret != ESP_OK) return ret;
+    
+    vTaskDelay(pdMS_TO_TICKS(10));
+    
+    // Set display clock divide ratio and oscillator frequency
+    ret = ssd1306_write_command(SSD1306_CMD_SET_CLOCK_DIV);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x80);
+    if (ret != ESP_OK) return ret;
+    
+    // Set multiplex ratio
+    ret = ssd1306_write_command(SSD1306_CMD_SET_MULTIPLEX_RATIO);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(SSD1306_HEIGHT - 1);
+    if (ret != ESP_OK) return ret;
+    
+    // Set display offset
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_OFFSET);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x00);
+    if (ret != ESP_OK) return ret;
+    
+    // Set start line
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_START_LINE | 0x0);
+    if (ret != ESP_OK) return ret;
+    
+    // Enable charge pump
+    ret = ssd1306_write_command(0x8D);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x14);
+    if (ret != ESP_OK) return ret;
+    
+    // Set memory addressing mode
+    ret = ssd1306_write_command(SSD1306_CMD_SET_MEMORY_ADDR_MODE);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x00); // Horizontal addressing mode
+    if (ret != ESP_OK) return ret;
+    
+    // Set segment re-map
+    ret = ssd1306_write_command(SSD1306_CMD_SET_SEGMENT_REMAP | 0x1);
+    if (ret != ESP_OK) return ret;
+    
+    // Set COM scan direction
+    ret = ssd1306_write_command(SSD1306_CMD_SET_COM_SCAN_DIR);
+    if (ret != ESP_OK) return ret;
+    
+    // Set COM pins configuration
+    ret = ssd1306_write_command(SSD1306_CMD_SET_COM_PINS);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x12);
+    if (ret != ESP_OK) return ret;
+    
+    // Set contrast
+    ret = ssd1306_write_command(SSD1306_CMD_SET_CONTRAST);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0xCF);
+    if (ret != ESP_OK) return ret;
+    
+    // Set pre-charge period
+    ret = ssd1306_write_command(SSD1306_CMD_SET_PRECHARGE_PERIOD);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0xF1);
+    if (ret != ESP_OK) return ret;
+    
+    // Set VCOMH deselect level
+    ret = ssd1306_write_command(SSD1306_CMD_SET_VCOMH_DESELECT);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x40);
+    if (ret != ESP_OK) return ret;
+    
+    // Set entire display on
+    ret = ssd1306_write_command(SSD1306_CMD_SET_ENTIRE_ON);
+    if (ret != ESP_OK) return ret;
+    
+    // Set normal/inverse display
+    ret = ssd1306_write_command(SSD1306_CMD_SET_NORMAL_INV);
+    if (ret != ESP_OK) return ret;
+    
+    // Display on
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_ON);
+    if (ret != ESP_OK) return ret;
+    
+    return ret;
+}
+
+/**
+ * @brief Clear the display
+ */
+static esp_err_t ssd1306_clear(void)
+{
+    uint8_t zeros[SSD1306_WIDTH];
+    memset(zeros, 0, SSD1306_WIDTH);
+    
+    esp_err_t ret = ssd1306_write_command(SSD1306_CMD_SET_COLUMN_ADDR);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(SSD1306_WIDTH - 1);
+    if (ret != ESP_OK) return ret;
+    
+    ret = ssd1306_write_command(SSD1306_CMD_SET_PAGE_ADDR);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command((SSD1306_HEIGHT / 8) - 1);
+    if (ret != ESP_OK) return ret;
+    
+    for (int i = 0; i < SSD1306_HEIGHT / 8; i++) {
+        ret = ssd1306_write_data(zeros, SSD1306_WIDTH);
+        if (ret != ESP_OK) return ret;
+    }
+    
+    return ret;
+}
+
+/**
+ * @brief Main application
+ */
+void app_main(void)
+{
+    ESP_LOGI(TAG, "Starting SSD1306 I2C Test");
+    
+    // Initialize I2C
+    esp_err_t ret = i2c_master_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C master init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "I2C master initialized successfully");
+    
+    // Initialize SSD1306
+    ret = ssd1306_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SSD1306 init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "SSD1306 initialized successfully");
+    
+    // Clear display
+    ret = ssd1306_clear();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SSD1306 clear failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "Display cleared successfully");
+    
+    ESP_LOGI(TAG, "SSD1306 test completed successfully!");
+}

--- a/ssd1306_corrected_example.c
+++ b/ssd1306_corrected_example.c
@@ -1,0 +1,259 @@
+/*
+ * SSD1306 I2C Communication - Corrected Example
+ * This example addresses common I2C communication issues
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/i2c.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_err.h"
+
+static const char *TAG = "SSD1306";
+
+// I2C Configuration
+#define I2C_MASTER_SCL_IO           22    /*!< GPIO number used for I2C master clock */
+#define I2C_MASTER_SDA_IO           21    /*!< GPIO number used for I2C master data  */
+#define I2C_MASTER_NUM              0     /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
+#define I2C_MASTER_FREQ_HZ          100000 /*!< I2C master clock frequency */
+#define I2C_MASTER_TX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE   0     /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_TIMEOUT_MS       1000
+
+// SSD1306 Configuration
+#define SSD1306_I2C_ADDR            0x3C  /*!< I2C address for SSD1306 */
+#define SSD1306_WIDTH               128
+#define SSD1306_HEIGHT              64
+
+// SSD1306 Commands
+#define SSD1306_CMD_SET_MEMORY_ADDR_MODE    0x20
+#define SSD1306_CMD_SET_COLUMN_ADDR         0x21
+#define SSD1306_CMD_SET_PAGE_ADDR           0x22
+#define SSD1306_CMD_SET_DISPLAY_START_LINE  0x40
+#define SSD1306_CMD_SET_SEGMENT_REMAP       0xA0
+#define SSD1306_CMD_SET_MULTIPLEX_RATIO     0xA8
+#define SSD1306_CMD_SET_COM_SCAN_DIR        0xC0
+#define SSD1306_CMD_SET_DISPLAY_OFFSET      0xD3
+#define SSD1306_CMD_SET_CLOCK_DIV           0xD5
+#define SSD1306_CMD_SET_PRECHARGE_PERIOD    0xD9
+#define SSD1306_CMD_SET_COM_PINS            0xDA
+#define SSD1306_CMD_SET_VCOMH_DESELECT      0xDB
+#define SSD1306_CMD_SET_CONTRAST            0x81
+#define SSD1306_CMD_SET_ENTIRE_ON           0xA4
+#define SSD1306_CMD_SET_NORMAL_INV           0xA6
+#define SSD1306_CMD_SET_DISPLAY_ON          0xAF
+#define SSD1306_CMD_SET_DISPLAY_OFF         0xAE
+
+/**
+ * @brief Initialize I2C master
+ */
+static esp_err_t i2c_master_init(void)
+{
+    int i2c_master_port = I2C_MASTER_NUM;
+
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = I2C_MASTER_FREQ_HZ,
+    };
+
+    i2c_param_config(i2c_master_port, &conf);
+
+    return i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+}
+
+/**
+ * @brief Write a command to SSD1306
+ */
+static esp_err_t ssd1306_write_command(uint8_t command)
+{
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, 0x00, true); // Control byte: Co=0, D/C#=0
+    i2c_master_write_byte(cmd, command, true);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    return ret;
+}
+
+/**
+ * @brief Write data to SSD1306
+ */
+static esp_err_t ssd1306_write_data(uint8_t *data, size_t len)
+{
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (SSD1306_I2C_ADDR << 1) | I2C_MASTER_WRITE, true);
+    i2c_master_write_byte(cmd, 0x40, true); // Control byte: Co=0, D/C#=1
+    i2c_master_write(cmd, data, len, true);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(cmd);
+    return ret;
+}
+
+/**
+ * @brief Initialize SSD1306 display
+ */
+static esp_err_t ssd1306_init(void)
+{
+    esp_err_t ret = ESP_OK;
+    
+    // Display off
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_OFF);
+    if (ret != ESP_OK) return ret;
+    
+    vTaskDelay(pdMS_TO_TICKS(10));
+    
+    // Set display clock divide ratio and oscillator frequency
+    ret = ssd1306_write_command(SSD1306_CMD_SET_CLOCK_DIV);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x80);
+    if (ret != ESP_OK) return ret;
+    
+    // Set multiplex ratio
+    ret = ssd1306_write_command(SSD1306_CMD_SET_MULTIPLEX_RATIO);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(SSD1306_HEIGHT - 1);
+    if (ret != ESP_OK) return ret;
+    
+    // Set display offset
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_OFFSET);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x00);
+    if (ret != ESP_OK) return ret;
+    
+    // Set start line
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_START_LINE | 0x0);
+    if (ret != ESP_OK) return ret;
+    
+    // Enable charge pump
+    ret = ssd1306_write_command(0x8D);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x14);
+    if (ret != ESP_OK) return ret;
+    
+    // Set memory addressing mode
+    ret = ssd1306_write_command(SSD1306_CMD_SET_MEMORY_ADDR_MODE);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x00); // Horizontal addressing mode
+    if (ret != ESP_OK) return ret;
+    
+    // Set segment re-map
+    ret = ssd1306_write_command(SSD1306_CMD_SET_SEGMENT_REMAP | 0x1);
+    if (ret != ESP_OK) return ret;
+    
+    // Set COM scan direction
+    ret = ssd1306_write_command(SSD1306_CMD_SET_COM_SCAN_DIR);
+    if (ret != ESP_OK) return ret;
+    
+    // Set COM pins configuration
+    ret = ssd1306_write_command(SSD1306_CMD_SET_COM_PINS);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x12);
+    if (ret != ESP_OK) return ret;
+    
+    // Set contrast
+    ret = ssd1306_write_command(SSD1306_CMD_SET_CONTRAST);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0xCF);
+    if (ret != ESP_OK) return ret;
+    
+    // Set pre-charge period
+    ret = ssd1306_write_command(SSD1306_CMD_SET_PRECHARGE_PERIOD);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0xF1);
+    if (ret != ESP_OK) return ret;
+    
+    // Set VCOMH deselect level
+    ret = ssd1306_write_command(SSD1306_CMD_SET_VCOMH_DESELECT);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0x40);
+    if (ret != ESP_OK) return ret;
+    
+    // Set entire display on
+    ret = ssd1306_write_command(SSD1306_CMD_SET_ENTIRE_ON);
+    if (ret != ESP_OK) return ret;
+    
+    // Set normal/inverse display
+    ret = ssd1306_write_command(SSD1306_CMD_SET_NORMAL_INV);
+    if (ret != ESP_OK) return ret;
+    
+    // Display on
+    ret = ssd1306_write_command(SSD1306_CMD_SET_DISPLAY_ON);
+    if (ret != ESP_OK) return ret;
+    
+    return ret;
+}
+
+/**
+ * @brief Clear the display
+ */
+static esp_err_t ssd1306_clear(void)
+{
+    uint8_t zeros[SSD1306_WIDTH];
+    memset(zeros, 0, SSD1306_WIDTH);
+    
+    esp_err_t ret = ssd1306_write_command(SSD1306_CMD_SET_COLUMN_ADDR);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(SSD1306_WIDTH - 1);
+    if (ret != ESP_OK) return ret;
+    
+    ret = ssd1306_write_command(SSD1306_CMD_SET_PAGE_ADDR);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command(0);
+    if (ret != ESP_OK) return ret;
+    ret = ssd1306_write_command((SSD1306_HEIGHT / 8) - 1);
+    if (ret != ESP_OK) return ret;
+    
+    for (int i = 0; i < SSD1306_HEIGHT / 8; i++) {
+        ret = ssd1306_write_data(zeros, SSD1306_WIDTH);
+        if (ret != ESP_OK) return ret;
+    }
+    
+    return ret;
+}
+
+/**
+ * @brief Main application
+ */
+void app_main(void)
+{
+    ESP_LOGI(TAG, "Starting SSD1306 I2C Test");
+    
+    // Initialize I2C
+    esp_err_t ret = i2c_master_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C master init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "I2C master initialized successfully");
+    
+    // Initialize SSD1306
+    ret = ssd1306_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SSD1306 init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "SSD1306 initialized successfully");
+    
+    // Clear display
+    ret = ssd1306_clear();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SSD1306 clear failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "Display cleared successfully");
+    
+    ESP_LOGI(TAG, "SSD1306 test completed successfully!");
+}


### PR DESCRIPTION
Implement corrected ESP32 I2C configuration and SSD1306 display example with diagnostic tools to resolve I2C communication failures.

The previous I2C setup resulted in `I2C hardware NACK` and `ESP_ERR_INVALID_STATE` errors, likely due to incorrect GPIO pin assignments (e.g., using GPIO 4/5 instead of 21/22), missing pull-up resistors, and an incomplete SSD1306 initialization sequence. This PR provides a robust I2C master configuration, a complete SSD1306 initialization, and an I2C scanner tool to help diagnose and prevent these common issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ed8f4ab-83c7-4279-8896-c38d4ea0d626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ed8f4ab-83c7-4279-8896-c38d4ea0d626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

